### PR TITLE
API and interface streamlining

### DIFF
--- a/automaton.go
+++ b/automaton.go
@@ -35,6 +35,24 @@ type Automaton interface {
 	Accept(int, byte) int
 }
 
+// AutomatonContains implements an generic Contains() method which works
+// on any implementation of Automaton
+func AutomatonContains(a Automaton, k []byte) bool {
+	i := 0
+	curr := a.Start()
+	for a.CanMatch(curr) && i < len(k) {
+		curr = a.Accept(curr, k[i])
+		if curr == noneAddr {
+			break
+		}
+		i++
+	}
+	if i != len(k) {
+		return false
+	}
+	return a.IsMatch(curr)
+}
+
 // AlwaysMatch is an Automaton implementation which always matches
 type AlwaysMatch struct{}
 

--- a/decoder_v1_test.go
+++ b/decoder_v1_test.go
@@ -34,12 +34,8 @@ func TestShortHeader(t *testing.T) {
 	}
 }
 
-func TestDecoderParseFooter(t *testing.T) {
+func TestDecoderRootLen(t *testing.T) {
 	d := newDecoderV1([]byte{1, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0})
-	err := d.parseFooter()
-	if err != nil {
-		t.Fatal(err)
-	}
 	if d.getLen() != 1 {
 		t.Fatalf("expected parsed footer length 1, got %d", d.len)
 	}

--- a/encoding.go
+++ b/encoding.go
@@ -46,7 +46,6 @@ func registerEncoder(ver int, cons encoderConstructor) {
 }
 
 type decoder interface {
-	start(f *FST) error
 	getRoot() int
 	getLen() int
 	stateAt(addr int) (fstState, error)

--- a/fst_iterator.go
+++ b/fst_iterator.go
@@ -91,7 +91,7 @@ func (i *Iterator) pointTo(key []byte) error {
 		autCurr := i.autStatesStack[len(i.autStatesStack)-1]
 
 		pos, nextAddr, nextVal := curr.TransitionFor(key[j])
-		if nextAddr < 0 {
+		if nextAddr == noneAddr {
 			// needed transition doesn't exist
 			// find last trans before the one we needed
 			for q := 0; q < curr.NumTransitions(); q++ {

--- a/transducer.go
+++ b/transducer.go
@@ -1,0 +1,55 @@
+//  Copyright (c) 2017 Couchbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vellum
+
+// Transducer represents the general contract of a byte-based finite transducer
+type Transducer interface {
+
+	// all transducers are also automatons
+	Automaton
+
+	// IsMatchWithValue returns true if and only if the state is a match
+	// additionally it returns a states final value (if any)
+	IsMatchWithVal(int) (bool, uint64)
+
+	// Accept returns the next state given the input to the specified state
+	// additionally it returns the value associated with the transition
+	AcceptWithVal(int, byte) (int, uint64)
+}
+
+// TransducerGet implements an generic Get() method which works
+// on any implementation of Transducer
+// The caller MUST check the boolean return value for a match.
+// Zero is a valid value regardless of match status,
+// and if it is NOT a match, the value collected so far is returned.
+func TransducerGet(t Transducer, k []byte) (bool, uint64) {
+	var total uint64
+	i := 0
+	curr := t.Start()
+	for t.CanMatch(curr) && i < len(k) {
+		var transVal uint64
+		curr, transVal = t.AcceptWithVal(curr, k[i])
+		if curr == noneAddr {
+			break
+		}
+		total += transVal
+		i++
+	}
+	if i != len(k) {
+		return false, total
+	}
+	match, finalVal := t.IsMatchWithVal(curr)
+	return match, total + finalVal
+}

--- a/vellum.go
+++ b/vellum.go
@@ -72,5 +72,5 @@ func Open(path string) (*FST, error) {
 
 // Load will return the FST represented by the provided byte slice.
 func Load(data []byte) (*FST, error) {
-	return newFST(data)
+	return new(data, nil)
 }

--- a/vellum_mmap.go
+++ b/vellum_mmap.go
@@ -53,17 +53,8 @@ func open(path string) (*FST, error) {
 		_ = f.Close()
 		return nil, err
 	}
-	rv := &FST{
-		f: &mmapWrapper{
-			f:  f,
-			mm: mm,
-		},
-		data: mm,
-	}
-	err = rv.initFST()
-	if err != nil {
-		_ = rv.Close()
-		return nil, err
-	}
-	return rv, nil
+	return new(mm, &mmapWrapper{
+		f:  f,
+		mm: mm,
+	})
 }

--- a/vellum_nommap.go
+++ b/vellum_nommap.go
@@ -20,15 +20,8 @@ import "io/ioutil"
 
 func open(path string) (*FST, error) {
 	data, err := ioutil.ReadFile(string)
-	rv := &FST{
-		data: data,
-	}
 	if err != nil {
 		return nil, err
 	}
-	err = rv.initFST()
-	if err != nil {
-		return nil, err
-	}
-	return rv, nil
+	return new(data, nil)
 }

--- a/vellum_test.go
+++ b/vellum_test.go
@@ -109,6 +109,34 @@ func TestRoundTripSimple(t *testing.T) {
 	if ok, _ := fst.Contains([]byte("x")); ok {
 		t.Errorf("expected to not contain x, but did")
 	}
+
+	// now try accessing it through the Automaton interface
+	exists := AutomatonContains(fst, []byte("mon"))
+	if !exists {
+		t.Errorf("expected key 'mon' to exist, doesn't")
+	}
+
+	exists = AutomatonContains(fst, []byte("mons"))
+	if exists {
+		t.Errorf("expected key 'mo' to not exist, does")
+	}
+
+	// now try accessing it through the Transducer interface
+	var val uint64
+	exists, val = TransducerGet(fst, []byte("mon"))
+	if !exists {
+		t.Errorf("expected key 'mon' to exist, doesn't")
+	}
+	if val != 2 {
+		t.Errorf("expected val 2, got %d", val)
+	}
+
+	// now try accessing it through the Transducer interface
+	// for key that doesn't exist
+	exists, _ = TransducerGet(fst, []byte("mons"))
+	if exists {
+		t.Errorf("expected key 'mo' to not exist, does")
+	}
 }
 
 func TestRoundTripThousand(t *testing.T) {


### PR DESCRIPTION
new function AutomatonContains
 - general purpose contains method that works with any Automaton impl

new Transducer interface
 - Transducer implies Automaton
 - adds methods to work with values on transitions and final state

new function TransducerGet
 - general purpose method to get value out of any Tranducer impl

decoder interface simplification
 - removed start method

decoderv1 impl modified
 - returns noneAddr not -1 on error/invalid transition
 - getRoot/getLen work direclty on data, removing need for start method

fst simplified
 - removed init method, combined into simplified new
 - tracks data type (for future use)
 - Load method reuses common new method now
 - mmap/nommap open methods reuse common new method now
 - ~~Get() method order of returned values now changed from (val,exists,err)
   to (exists,val,err).  The thinking here is that this is more natural
   extension Contains method which returns (exists,err).  If it doesn't exist
   you probaby don't care about the value, so feels more correct left-to-right.~~

FST now implements Automaton and Transducer interfaces!!!
 - at the moment this isn't used for anything
 - Get/Iteration is still faster using direct methods on the *FST since
   they avoid reparsing node state each time
 - but, I like having this API symmetry and I think it allows for some
   more common code in the future