### PR TITLE
new MergeIterator and Merge building function

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -86,10 +86,19 @@ func (b *Builder) Insert(key []byte, val uint64) error {
 	if err != nil {
 		return err
 	}
-	b.last = key
+	b.copyLastKey(key)
 	b.unfinished.addSuffix(key[prefixLen:], out)
 
 	return nil
+}
+
+func (b *Builder) copyLastKey(key []byte) {
+	if b.last == nil {
+		b.last = make([]byte, 0, 64)
+	} else {
+		b.last = b.last[:0]
+	}
+	b.last = append(b.last, key...)
 }
 
 // Close MUST be called after inserting all values.

--- a/fst.go
+++ b/fst.go
@@ -177,14 +177,14 @@ func (f *FST) AcceptWithVal(addr int, b byte) (int, uint64) {
 
 // Iterator returns a new Iterator capable of enumerating the key/value pairs
 // between the provided startKeyInclusive and endKeyExclusive.
-func (f *FST) Iterator(startKeyInclusive, endKeyExclusive []byte) (*Iterator, error) {
+func (f *FST) Iterator(startKeyInclusive, endKeyExclusive []byte) (*FSTIterator, error) {
 	return newIterator(f, startKeyInclusive, endKeyExclusive, nil)
 }
 
 // Search returns a new Iterator capable of enumerating the key/value pairs
 // between the provided startKeyInclusive and endKeyExclusive that also
 // satisfy the provided automaton.
-func (f *FST) Search(aut Automaton, startKeyInclusive, endKeyExclusive []byte) (*Iterator, error) {
+func (f *FST) Search(aut Automaton, startKeyInclusive, endKeyExclusive []byte) (*FSTIterator, error) {
 	return newIterator(f, startKeyInclusive, endKeyExclusive, aut)
 }
 

--- a/merge_iterator.go
+++ b/merge_iterator.go
@@ -55,7 +55,7 @@ func NewMergeIterator(itrs []Iterator, f MergeFunc) (*MergeIterator, error) {
 	}
 	rv.init()
 	if rv.lowK == nil {
-		return nil, ErrIteratorDone
+		return rv, ErrIteratorDone
 	}
 	return rv, nil
 }
@@ -68,6 +68,9 @@ func (m *MergeIterator) init() {
 }
 
 func (m *MergeIterator) updateMatches() {
+	if len(m.itrs) < 1 {
+		return
+	}
 	m.lowK = m.currKs[0]
 	m.lowIdxs = m.lowIdxs[:0]
 	m.lowIdxs = append(m.lowIdxs, 0)

--- a/merge_iterator.go
+++ b/merge_iterator.go
@@ -1,0 +1,185 @@
+//  Copyright (c) 2017 Couchbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vellum
+
+import (
+	"bytes"
+)
+
+// MergeFunc is used to choose the new value for a key when merging a slice
+// of iterators, and the same key is observed with multiple values.
+// Values presented to the MergeFunc will be in the same order as the
+// original slice creating the MergeIterator.  This allows some MergeFunc
+// implementations to prioritize one iterator over another.
+type MergeFunc func([]uint64) uint64
+
+// MergeIterator implements the Iterator interface by traversing a slice
+// of iterators and merging the contents of them.  If the same key exists
+// in mulitipe underlying iterators, a user-provided MergeFunc will be
+// invoked to choose the new value.
+type MergeIterator struct {
+	itrs   []Iterator
+	f      MergeFunc
+	currKs [][]byte
+	currVs []uint64
+
+	lowK    []byte
+	lowV    uint64
+	lowIdxs []int
+
+	mergeV []uint64
+}
+
+// NewMergeIterator creates a new MergeIterator over the provided slice of
+// Iterators and with the specified MergeFunc to resolve duplicate keys.
+func NewMergeIterator(itrs []Iterator, f MergeFunc) (*MergeIterator, error) {
+	rv := &MergeIterator{
+		itrs:    itrs,
+		f:       f,
+		currKs:  make([][]byte, len(itrs)),
+		currVs:  make([]uint64, len(itrs)),
+		lowIdxs: make([]int, 0, len(itrs)),
+		mergeV:  make([]uint64, 0, len(itrs)),
+	}
+	rv.init()
+	if rv.lowK == nil {
+		return nil, ErrIteratorDone
+	}
+	return rv, nil
+}
+
+func (m *MergeIterator) init() {
+	for i, itr := range m.itrs {
+		m.currKs[i], m.currVs[i] = itr.Current()
+	}
+	m.updateMatches()
+}
+
+func (m *MergeIterator) updateMatches() {
+	m.lowK = m.currKs[0]
+	m.lowIdxs = m.lowIdxs[:0]
+	m.lowIdxs = append(m.lowIdxs, 0)
+	for i := 1; i < len(m.itrs); i++ {
+		if m.currKs[i] == nil {
+			continue
+		}
+		cmp := bytes.Compare(m.currKs[i], m.lowK)
+		if m.lowK == nil || cmp < 0 {
+			// reached a new low
+			m.lowK = m.currKs[i]
+			m.lowIdxs = m.lowIdxs[:0]
+			m.lowIdxs = append(m.lowIdxs, i)
+		} else if cmp == 0 {
+			m.lowIdxs = append(m.lowIdxs, i)
+		}
+	}
+	if len(m.lowIdxs) > 1 {
+		// merge multiple values
+		m.mergeV = m.mergeV[:0]
+		for _, vi := range m.lowIdxs {
+			m.mergeV = append(m.mergeV, m.currVs[vi])
+		}
+		m.lowV = m.f(m.mergeV)
+	} else if len(m.lowIdxs) == 1 {
+		m.lowV = m.currVs[m.lowIdxs[0]]
+	}
+}
+
+// Current returns the key and value currently pointed to by this iterator.
+// If the iterator is not pointing at a valid value (because Iterator/Next/Seek)
+// returned an error previously, it may return nil,0.
+func (m *MergeIterator) Current() ([]byte, uint64) {
+	return m.lowK, m.lowV
+}
+
+// Next advances this iterator to the next key/value pair.  If there is none,
+// then ErrIteratorDone is returned.
+func (m *MergeIterator) Next() error {
+	// move all the current low iterators to next
+	for _, vi := range m.lowIdxs {
+		err := m.itrs[vi].Next()
+		if err != nil && err != ErrIteratorDone {
+			return err
+		}
+		m.currKs[vi], m.currVs[vi] = m.itrs[vi].Current()
+	}
+	m.updateMatches()
+	if m.lowK == nil {
+		return ErrIteratorDone
+	}
+	return nil
+}
+
+// Seek advances this iterator to the specified key/value pair.  If this key
+// is not in the FST, Current() will return the next largest key.  If this
+// seek operation would go past the last key, then ErrIteratorDone is returned.
+func (m *MergeIterator) Seek(key []byte) error {
+	for i := range m.itrs {
+		err := m.itrs[i].Seek(key)
+		if err != nil && err != ErrIteratorDone {
+			return err
+		}
+	}
+	m.updateMatches()
+	if m.lowK == nil {
+		return ErrIteratorDone
+	}
+	return nil
+}
+
+// Close will attempt to close all the underlying Iterators.  If any errors
+// are encountered, the first will be returned.
+func (m *MergeIterator) Close() error {
+	var rv error
+	for i := range m.itrs {
+		// close all iterators, return first error if any
+		err := m.itrs[i].Close()
+		if rv == nil {
+			rv = err
+		}
+	}
+	return rv
+}
+
+// MergeMin chooses the minimum value
+func MergeMin(vals []uint64) uint64 {
+	rv := vals[0]
+	for _, v := range vals[1:] {
+		if v < rv {
+			rv = v
+		}
+	}
+	return rv
+}
+
+// MergeMax chooses the maximum value
+func MergeMax(vals []uint64) uint64 {
+	rv := vals[0]
+	for _, v := range vals[1:] {
+		if v > rv {
+			rv = v
+		}
+	}
+	return rv
+}
+
+// MergeSum sums the values
+func MergeSum(vals []uint64) uint64 {
+	rv := vals[0]
+	for _, v := range vals[1:] {
+		rv += v
+	}
+	return rv
+}

--- a/merge_iterator_test.go
+++ b/merge_iterator_test.go
@@ -230,3 +230,40 @@ func TestMergeFunc(t *testing.T) {
 		})
 	}
 }
+
+func TestEmptyMergeIterator(t *testing.T) {
+	mi, err := NewMergeIterator([]Iterator{}, MergeMin)
+	if err != ErrIteratorDone {
+		t.Fatalf("expected iterator done, got %v", err)
+	}
+
+	// should get valid merge iterator anyway
+	if mi == nil {
+		t.Fatalf("expected non-nil merge iterator")
+	}
+
+	// current returns nil, 0 per interface spec
+	ck, cv := mi.Current()
+	if ck != nil {
+		t.Errorf("expected current to return nil key, got %v", ck)
+	}
+	if cv != 0 {
+		t.Errorf("expected current to return 0 val, got %d", cv)
+	}
+
+	// calling Next/Seek continues to return ErrIteratorDone
+	err = mi.Next()
+	if err != ErrIteratorDone {
+		t.Errorf("expected iterator done, got %v", err)
+	}
+	err = mi.Seek([]byte("anywhere"))
+	if err != ErrIteratorDone {
+		t.Errorf("expected iterator done, got %v", err)
+	}
+
+	err = mi.Close()
+	if err != nil {
+		t.Errorf("error closing %v", err)
+	}
+
+}

--- a/merge_iterator_test.go
+++ b/merge_iterator_test.go
@@ -1,0 +1,232 @@
+//  Copyright (c) 2017 Couchbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vellum
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func TestMergeIterator(t *testing.T) {
+
+	tests := []struct {
+		desc  string
+		in    []map[string]uint64
+		merge MergeFunc
+		want  map[string]uint64
+	}{
+		{
+			desc: "two non-empty iterators with no duplicate keys",
+			in: []map[string]uint64{
+				map[string]uint64{
+					"a": 1,
+					"c": 3,
+					"e": 5,
+				},
+				map[string]uint64{
+					"b": 2,
+					"d": 4,
+					"f": 6,
+				},
+			},
+			merge: func(mvs []uint64) uint64 {
+				return mvs[0]
+			},
+			want: map[string]uint64{
+				"a": 1,
+				"c": 3,
+				"e": 5,
+				"b": 2,
+				"d": 4,
+				"f": 6,
+			},
+		},
+		{
+			desc: "two non-empty iterators with duplicate keys summed",
+			in: []map[string]uint64{
+				map[string]uint64{
+					"a": 1,
+					"c": 3,
+					"e": 5,
+				},
+				map[string]uint64{
+					"a": 2,
+					"c": 4,
+					"e": 6,
+				},
+			},
+			merge: func(mvs []uint64) uint64 {
+				var rv uint64
+				for _, mv := range mvs {
+					rv += mv
+				}
+				return rv
+			},
+			want: map[string]uint64{
+				"a": 3,
+				"c": 7,
+				"e": 11,
+			},
+		},
+
+		{
+			desc: "non-working example",
+			in: []map[string]uint64{
+				map[string]uint64{
+					"mon":   2,
+					"tues":  3,
+					"thurs": 5,
+					"tye":   99,
+				},
+				map[string]uint64{
+					"bold": 25,
+					"last": 1,
+					"next": 500,
+					"tank": 0,
+				},
+			},
+			merge: func(mvs []uint64) uint64 {
+				return mvs[0]
+			},
+			want: map[string]uint64{
+				"mon":   2,
+				"tues":  3,
+				"thurs": 5,
+				"tye":   99,
+				"bold":  25,
+				"last":  1,
+				"next":  500,
+				"tank":  0,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			var itrs []Iterator
+			for i := range test.in {
+				itr, err := newTestIterator(test.in[i])
+				if err != nil && err != ErrIteratorDone {
+					t.Fatalf("error creating iterator: %v", err)
+				}
+				if err == nil {
+					itrs = append(itrs, itr)
+				}
+			}
+			mi, err := NewMergeIterator(itrs, test.merge)
+			if err != nil && err != ErrIteratorDone {
+				t.Fatalf("error creating iterator: %v", err)
+			}
+			got := make(map[string]uint64)
+			for err == nil {
+				currk, currv := mi.Current()
+				err = mi.Next()
+				got[string(currk)] = currv
+			}
+			if err != nil && err != ErrIteratorDone {
+				t.Fatalf("error iterating: %v", err)
+			}
+
+			if !reflect.DeepEqual(got, test.want) {
+				t.Errorf("expected %v, got %v", test.want, got)
+			}
+		})
+	}
+}
+
+type testIterator struct {
+	vals map[int]uint64
+	keys []string
+	curr int
+}
+
+func newTestIterator(in map[string]uint64) (*testIterator, error) {
+	rv := &testIterator{
+		vals: make(map[int]uint64, len(in)),
+	}
+	for k := range in {
+		rv.keys = append(rv.keys, k)
+	}
+	sort.Strings(rv.keys)
+	for i, k := range rv.keys {
+		rv.vals[i] = in[k]
+	}
+	return rv, nil
+}
+
+func (m *testIterator) Current() ([]byte, uint64) {
+	if m.curr >= len(m.keys) {
+		return nil, 0
+	}
+	return []byte(m.keys[m.curr]), m.vals[m.curr]
+}
+
+func (m *testIterator) Next() error {
+	m.curr++
+	if m.curr >= len(m.keys) {
+		return ErrIteratorDone
+	}
+	return nil
+}
+
+func (m *testIterator) Seek(key []byte) error {
+	m.curr = sort.SearchStrings(m.keys, string(key))
+	if m.curr >= len(m.keys) {
+		return ErrIteratorDone
+	}
+	return nil
+}
+
+func (m *testIterator) Close() error {
+	return nil
+}
+
+func TestMergeFunc(t *testing.T) {
+	tests := []struct {
+		desc  string
+		in    []uint64
+		merge MergeFunc
+		want  uint64
+	}{
+		{
+			desc:  "min",
+			in:    []uint64{5, 99, 1},
+			merge: MergeMin,
+			want:  1,
+		},
+		{
+			desc:  "max",
+			in:    []uint64{5, 99, 1},
+			merge: MergeMax,
+			want:  99,
+		},
+		{
+			desc:  "sum",
+			in:    []uint64{5, 99, 1},
+			merge: MergeSum,
+			want:  105,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			got := test.merge(test.in)
+			if test.want != got {
+				t.Errorf("expected %d, got %d", test.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- fix builder, to copy last key, not use reference, which it doesn't own
- make Iterator an interface
- MergeIterator can iterate over several Iterators and invoke custom
  MergeFunc when the same key appears on multiple Iterators
- Merge function allows you to build new FST by merging several others

fixes #3