### PR TITLE
Add Reset() method to Iterator

### DIFF
--- a/automaton.go
+++ b/automaton.go
@@ -80,3 +80,6 @@ func (m *AlwaysMatch) WillAlwaysMatch(int) bool {
 func (m *AlwaysMatch) Accept(int, byte) int {
 	return 0
 }
+
+// creating an alwaysMatchAutomaton to avoid unnecesary repeated allocations.
+var alwaysMatchAutomaton = &AlwaysMatch{}

--- a/merge_iterator_test.go
+++ b/merge_iterator_test.go
@@ -190,6 +190,10 @@ func (m *testIterator) Seek(key []byte) error {
 	return nil
 }
 
+func (m *testIterator) Reset(f *FST, startKeyInclusive, endKeyExclusive []byte, aut Automaton) error {
+	return nil
+}
+
 func (m *testIterator) Close() error {
 	return nil
 }


### PR DESCRIPTION
I found Iterator creation was expensive in some benchmarks. Adding a `Reset()` method to the interface to allow for iterator pooling. 

